### PR TITLE
feat: Добавить классы FilmControllers и UserControllers

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/FilmorateApplication.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/FilmorateApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class FilmorateApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(FilmorateApplication.class);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(FilmorateApplication.class);
+    }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/GsonBuilder.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/GsonBuilder.java
@@ -1,4 +1,4 @@
-package ru.yandex.practicum.filmorate.model;
+package ru.yandex.practicum.filmorate;
 
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -1,9 +1,10 @@
-package ru.yandex.practicum.filmorate;
+package ru.yandex.practicum.filmorate.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import ru.yandex.practicum.filmorate.model.Film;
-import ru.yandex.practicum.filmorate.service.Service;
+import ru.yandex.practicum.filmorate.service.FilmService;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -12,8 +13,8 @@ import java.util.List;
 @RequestMapping("/films")
 @Slf4j
 public class FilmController {
-
-    private final Service<Film> filmService = new Service<>();
+    @Autowired
+    private FilmService filmService;
 
     @PostMapping
     public Film addFilm(@Valid @RequestBody Film film) {
@@ -28,8 +29,7 @@ public class FilmController {
         if (filmService.update(film)) {
             return film;
         } else {
-            log.info("Ошибка! передан неизвестный фильм");
-            throw new IllegalAccessError();
+            throw new IllegalAccessError("Отсутствует фильм с значением поля id = " + film.getId());
         }
     }
 
@@ -37,5 +37,21 @@ public class FilmController {
     public List<Film> getFilms() {
         log.info("Получен запрос Get /film");
         return filmService.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public Film getById(@PathVariable int id) {
+        log.info("Получен запрос Get /user");
+        try {
+            return filmService.get(id);
+        } catch (NullPointerException e) {
+            throw new IllegalAccessError(e.getMessage());
+        }
+    }
+
+    @GetMapping("/popular")
+    public List<Film> getFilms(@RequestParam(defaultValue = "10") int count) {
+        log.info("Получен запрос Get /film/popular");
+        return filmService.getFilmsRating(count);
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmLikesController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmLikesController.java
@@ -1,0 +1,31 @@
+package ru.yandex.practicum.filmorate.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import ru.yandex.practicum.filmorate.model.FilmUsersLikes;
+import ru.yandex.practicum.filmorate.service.FilmService;
+
+@RestController
+@RequestMapping("/films/{id}/like")
+@Slf4j
+public class FilmLikesController {
+    @Autowired
+    private FilmService filmService;
+
+    @PutMapping("/{userId}")
+    public FilmUsersLikes addLike(@PathVariable(value = "id") int filmId, @PathVariable int userId) {
+        log.info("Получен запрос Put /films/{}/like {}", filmId, userId);
+        return filmService.addLike(filmId, userId);
+    }
+
+    @DeleteMapping("/{userId}")
+    public FilmUsersLikes removeLike(@PathVariable(value = "id") int filmId, @PathVariable int userId) {
+        log.info("Получен запрос Delete /films/{}/like {}", filmId, userId);
+        try {
+            return filmService.removeLike(filmId, userId);
+        } catch (NullPointerException e) {
+            throw new IllegalAccessError(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FriendController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FriendController.java
@@ -1,0 +1,48 @@
+package ru.yandex.practicum.filmorate.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import ru.yandex.practicum.filmorate.model.FriendLink;
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.service.UserService;
+
+import java.util.List;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/users/{id}/friends")
+@Slf4j
+public class FriendController {
+    @Autowired
+    private UserService userService;
+
+    @PutMapping("/{friendId}")
+    public FriendLink addFriend(@PathVariable int id, @PathVariable int friendId) {
+        log.info("Получен запрос Put /users/{}/friends {}", id, friendId);
+        try {
+            return userService.addFriendLink(id, friendId);
+        } catch (NullPointerException e) {
+            throw new IllegalAccessError(e.getMessage());
+        }
+
+    }
+
+    @DeleteMapping("/{friendId}")
+    public FriendLink removeFriend(@PathVariable int id, @PathVariable int friendId) {
+        log.info("Получен запрос Delete /users/{}/friends {}", id, friendId);
+        return userService.removeFriendLink(id, friendId);
+    }
+
+    @GetMapping
+    public List<User> getFriends(@PathVariable int id) {
+        log.info("Получен запрос Get /users/{}/friends ", id);
+        return userService.getFriends(id);
+    }
+
+    @GetMapping("/common/{otherId}")
+    public Set<User> getCommonFriendList(@PathVariable int id, @PathVariable int otherId) {
+        log.info("Получен запрос Get /users/{}/friends {}", id, otherId);
+        return userService.getCommonFriendsList(id, otherId);
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/UserController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/UserController.java
@@ -1,6 +1,7 @@
-package ru.yandex.practicum.filmorate;
+package ru.yandex.practicum.filmorate.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import ru.yandex.practicum.filmorate.model.User;
 import ru.yandex.practicum.filmorate.service.UserService;
@@ -13,7 +14,8 @@ import java.util.List;
 @Slf4j
 public class UserController {
 
-    UserService userService = new UserService();
+    @Autowired
+    private UserService userService;
 
     @PostMapping
     public User createUser(@Valid @RequestBody User user) {
@@ -28,8 +30,17 @@ public class UserController {
         if (userService.update(user)) {
             return user;
         } else {
-            log.info("Ошибка! передан неизвестный фильм");
-            throw new IllegalAccessError();
+            throw new IllegalAccessError("Неверный идентификатор");
+        }
+    }
+
+    @GetMapping("/{id}")
+    public User getById(@PathVariable int id) {
+        log.info("Получен запрос Get /user {}", id);
+        try {
+            return userService.get(id);
+        } catch (NullPointerException e) {
+            throw new IllegalAccessError(e.getMessage());
         }
     }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/handler/ExceptionHandler.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/handler/ExceptionHandler.java
@@ -1,0 +1,35 @@
+package ru.yandex.practicum.filmorate.handler;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.validation.ValidationException;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice("ru.yandex.practicum.filmorate.controller")
+public class ExceptionHandler {
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Map<String, String> handleValidationException(final ValidationException e) {
+        log.info("Ошибка! {}", e.getMessage());
+        return Map.of("Ошибка валидации", e.getMessage());
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, String> handleIllegalAccessError(final IllegalAccessError e) {
+        log.info("Ошибка! {}", e.getMessage());
+        return Map.of("Ошибка. Не найден искомый объект", e.getMessage());
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Map<String, String> handleRuntimeException(final RuntimeException e) {
+        log.info("Ошибка! {}", e.getMessage());
+        return Map.of("Ошибка!", e.getMessage());
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/Film.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/Film.java
@@ -1,12 +1,12 @@
 package ru.yandex.practicum.filmorate.model;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Positive;
 import lombok.Builder;
 import lombok.Data;
 import org.hibernate.validator.constraints.Length;
 import ru.yandex.practicum.filmorate.annotation.LocalDateMinDateConstraint;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Positive;
 import java.time.LocalDate;
 
 @Data

--- a/src/main/java/ru/yandex/practicum/filmorate/model/FilmUsersLikes.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/FilmUsersLikes.java
@@ -1,0 +1,33 @@
+package ru.yandex.practicum.filmorate.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@EqualsAndHashCode
+public class FilmUsersLikes {
+    private final Set<User> users;
+    @Setter
+    private Film film;
+
+    public FilmUsersLikes(Film film) {
+        this.film = film;
+        users = new HashSet<>();
+    }
+
+    public boolean addUser(User user) {
+        return users.add(user);
+    }
+
+    public boolean removeUser(User user) {
+        return users.remove(user);
+    }
+
+    public int getLikesCount() {
+        return users.size();
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/FriendLink.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/FriendLink.java
@@ -1,0 +1,48 @@
+package ru.yandex.practicum.filmorate.model;
+
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+public class FriendLink {
+
+    private final User userA;
+    private final User userB;
+
+    public FriendLink(User userA, User userB) {
+        if (userA == null || userB == null) {
+            throw new IllegalAccessError("Передан неверный идентификатор пользователя");
+        }
+        if (userA.equals(userB)) {
+            throw new IllegalAccessError();
+        }
+        this.userA = userA;
+        this.userB = userB;
+    }
+
+    public boolean isContains(int userId) {
+        return userA.getId() == userId || userB.getId() == userId;
+    }
+
+    public User getUserById(int userId) {
+        return userA.getId() == userId ? userA : userB.getId() == userId ? userB : null;
+    }
+
+    public User getFriendByUserId(int userId) {
+        return userA.getId() == userId ? userB : userB.getId() == userId ? userA : null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FriendLink that = (FriendLink) o;
+        return userA.equals(that.userA) || userB.equals(that.userB);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userA, userB);
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/User.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/User.java
@@ -4,7 +4,10 @@ import lombok.Builder;
 import lombok.Data;
 import ru.yandex.practicum.filmorate.annotation.NotContainsBlank;
 
-import javax.validation.constraints.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Past;
 import java.time.LocalDate;
 
 @Data

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -1,20 +1,39 @@
 package ru.yandex.practicum.filmorate.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.FilmUsersLikes;
+import ru.yandex.practicum.filmorate.storage.FilmStorage;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
+@org.springframework.stereotype.Service
 public class FilmService extends Service<Film> {
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private FilmStorage filmStorage;
 
-    public void add(Film film) {
-        this.add(film);
+    public FilmService(FilmStorage filmStorage) {
+        super(filmStorage);
     }
 
-    public boolean updateFilm(Film film) {
-        return update(film);
+    public FilmUsersLikes addLike(int filmId, int userId) {
+        return filmStorage.addLike(get(filmId), userService.get(userId));
     }
 
-    public List<Film> getFilms() {
-        return getAll();
+    public FilmUsersLikes removeLike(int filmId, int userId) {
+        return filmStorage.removeLike(get(filmId), userService.get(userId));
+    }
+
+    public List<Film> getFilmsRating(int count) {
+        return filmStorage.getAllFilmLikes().stream()
+                .sorted(Comparator.comparingInt(filmLikes -> filmLikes.getFilm().getId()))
+                .sorted(Comparator.comparingInt(FilmUsersLikes::getLikesCount).reversed())
+                .map(FilmUsersLikes::getFilm)
+                .limit(count)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/Service.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/Service.java
@@ -1,32 +1,39 @@
 package ru.yandex.practicum.filmorate.service;
 
 import ru.yandex.practicum.filmorate.model.Identifiable;
+import ru.yandex.practicum.filmorate.storage.Storage;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class Service<T extends Identifiable> {
 
-    protected final Map<Integer, T> storage = new HashMap<>();
-    private int sec = 0;
+    protected final Storage<T> storage;
+
+    public Service(Storage<T> storage) {
+        this.storage = storage;
+    }
 
     public boolean update(T item) {
-        if (storage.containsKey(item.getId())) {
-            storage.put(item.getId(), item);
+        if (storage.isContains(item.getId())) {
+            storage.update(item);
             return true;
         }
         return false;
     }
 
     public List<T> getAll() {
-        return storage.values().stream().collect(Collectors.toUnmodifiableList());
+        return storage.getAll();
+    }
+
+    public T get(int id) {
+        T item = storage.get(id);
+        if (item == null) {
+            throw new NullPointerException("Отсутствует объект с id = " + id);
+        }
+        return item;
     }
 
     public void add(T item) {
-        sec++;
-        storage.put(sec, item);
-        item.setId(sec);
+        storage.add(item);
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/UserService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/UserService.java
@@ -1,8 +1,23 @@
 package ru.yandex.practicum.filmorate.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import ru.yandex.practicum.filmorate.model.FriendLink;
 import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.storage.UserStorage;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@org.springframework.stereotype.Service
 public class UserService extends Service<User> {
+    @Autowired
+    private UserStorage userStorage;
+
+    public UserService(UserStorage userStorage) {
+        super(userStorage);
+    }
 
     @Override
     public void add(User user) {
@@ -16,9 +31,37 @@ public class UserService extends Service<User> {
         return super.update(user);
     }
 
+    public FriendLink addFriendLink(int userId, int friendId) {
+        FriendLink friendLinkAdded = generateFriendLink(userId, friendId);
+        userStorage.addFriendLink(friendLinkAdded);
+        return friendLinkAdded;
+    }
+
+    public FriendLink removeFriendLink(int userId, int friendId) {
+        FriendLink friendLinkRemoved = generateFriendLink(userId, friendId);
+        userStorage.removeFriendLink(friendLinkRemoved);
+        return friendLinkRemoved;
+    }
+
+    public List<User> getFriends(int userId) {
+        return userStorage.getFriends(userId).stream()
+                .sorted(Comparator.comparingInt(User::getId))
+                .collect(Collectors.toList());
+    }
+
+    public Set<User> getCommonFriendsList(int id, int otherId) {
+        List<User> friendListA = getFriends(id);
+        List<User> friendListB = getFriends(otherId);
+        return friendListA.stream().filter(friendListB::contains).collect(Collectors.toSet());
+    }
+
     private void checkName(User user) {
         if (user.getName() == null || user.getName().isBlank()) {
             user.setName(user.getLogin());
         }
+    }
+
+    private FriendLink generateFriendLink(int userAId, int userBId) {
+        return new FriendLink(get(userAId), get(userBId));
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/FilmStorage.java
@@ -1,0 +1,17 @@
+package ru.yandex.practicum.filmorate.storage;
+
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.FilmUsersLikes;
+import ru.yandex.practicum.filmorate.model.User;
+
+import java.util.List;
+
+public interface FilmStorage extends Storage<Film> {
+    FilmUsersLikes addLike(Film film, User user);
+
+    FilmUsersLikes removeLike(Film film, User user);
+
+    List<FilmUsersLikes> getAllFilmLikes();
+
+    FilmUsersLikes getFilmLikes(Film film);
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/InMemoryFilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/InMemoryFilmStorage.java
@@ -1,0 +1,58 @@
+package ru.yandex.practicum.filmorate.storage;
+
+import org.springframework.stereotype.Component;
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.FilmUsersLikes;
+import ru.yandex.practicum.filmorate.model.User;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class InMemoryFilmStorage extends InMemoryStorage<Film> implements FilmStorage {
+
+    protected final Map<Integer, FilmUsersLikes> filmLikes = new HashMap<>();
+
+    @Override
+    public Film add(Film film) {
+        super.add(film);
+        filmLikes.put(film.getId(), new FilmUsersLikes(film));
+        return film;
+    }
+
+    @Override
+    public Film update(Film film) {
+        super.update(film);
+        filmLikes.get(film.getId()).setFilm(film);
+        return film;
+    }
+
+    @Override
+    public FilmUsersLikes addLike(Film film, User user) {
+        FilmUsersLikes filmUsersLikes = getFilmLikes(film);
+        filmUsersLikes.addUser(user);
+        return filmUsersLikes;
+    }
+
+    @Override
+    public FilmUsersLikes removeLike(Film film, User user) {
+        if (user == null) {
+            throw new NullPointerException();
+        }
+        FilmUsersLikes filmUsersLikes = getFilmLikes(film);
+        filmUsersLikes.removeUser(user);
+        return filmUsersLikes;
+    }
+
+    @Override
+    public List<FilmUsersLikes> getAllFilmLikes() {
+        return new ArrayList<>(filmLikes.values());
+    }
+
+    @Override
+    public FilmUsersLikes getFilmLikes(Film film) {
+        return filmLikes.get(film.getId());
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/InMemoryStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/InMemoryStorage.java
@@ -1,0 +1,36 @@
+package ru.yandex.practicum.filmorate.storage;
+
+import ru.yandex.practicum.filmorate.model.Identifiable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class InMemoryStorage<T extends Identifiable> {
+
+    protected final Map<Integer, T> storage = new HashMap<>();
+
+    private int sec = 0;
+
+    public T add(T value) {
+        value.setId(++sec);
+        return storage.put(value.getId(), value);
+    }
+
+    public T update(T value) {
+        return storage.put(value.getId(), value);
+    }
+
+    public List<T> getAll() {
+        return new ArrayList<>(storage.values());
+    }
+
+    public T get(int id) {
+        return storage.get(id);
+    }
+
+    public boolean isContains(int id) {
+        return storage.containsKey(id);
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/InMemoryUserStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/InMemoryUserStorage.java
@@ -1,0 +1,37 @@
+package ru.yandex.practicum.filmorate.storage;
+
+import org.springframework.stereotype.Component;
+import ru.yandex.practicum.filmorate.model.FriendLink;
+import ru.yandex.practicum.filmorate.model.User;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class InMemoryUserStorage extends InMemoryStorage<User> implements UserStorage {
+    protected final Set<FriendLink> friendLinks = new HashSet<>();
+
+    @Override
+    public boolean isContains(FriendLink friendLink) {
+        return friendLinks.contains(friendLink);
+    }
+
+    @Override
+    public boolean addFriendLink(FriendLink friendLink) {
+        return friendLinks.add(friendLink);
+    }
+
+    @Override
+    public boolean removeFriendLink(FriendLink friendLink) {
+        return friendLinks.remove(friendLink);
+    }
+
+    @Override
+    public List<User> getFriends(int userId) {
+        return friendLinks.stream().filter(userLink -> userLink.isContains(userId))
+                .map(userLink -> userLink.getFriendByUserId(userId))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/Storage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/Storage.java
@@ -1,0 +1,15 @@
+package ru.yandex.practicum.filmorate.storage;
+
+import java.util.List;
+
+public interface Storage<T> {
+    T add(T item);
+
+    T update(T item);
+
+    T get(int id);
+
+    List<T> getAll();
+
+    boolean isContains(int id);
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/UserStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/UserStorage.java
@@ -1,0 +1,20 @@
+package ru.yandex.practicum.filmorate.storage;
+
+import ru.yandex.practicum.filmorate.model.FriendLink;
+import ru.yandex.practicum.filmorate.model.User;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public interface UserStorage extends Storage<User> {
+    Set<FriendLink> friendLinks = new HashSet<>();
+
+    boolean isContains(FriendLink friendLink);
+
+    boolean addFriendLink(FriendLink friendLink);
+
+    boolean removeFriendLink(FriendLink friendLink);
+
+    List<User> getFriends(int userId);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-logging.level.ru.yandex.practicum.filmorate.FilmController=debug
-logging.level.ru.yandex.practicum.filmorate.UserController=debug
+logging.level.ru.yandex.practicum.filmorate.controller.FilmController=info
+logging.level.ru.yandex.practicum.filmorate.controller.UserController=info


### PR DESCRIPTION
Контроллеры были разделены на 4 по причине сильных отличий эндпоинтов и логики использования: likes - реакции для фильмов, friends - добавление в друзья, users и films предоставляют простой функционал взаимодействия с основными моделями данных. 
Были созданы "базовые" классы Service и InMemoryStorage во избежание повторения кода, а также для того, чтобы сделать его более простым для сопровождения, так как в ином случае классы получились бы слишком громоздкие, что я посчитал, можно избежать.
Были созданы отдельные модели данных FriendLink и FilmUsersLikes. FriendLink предоставляет удобный интерфейс взаимодействия, скрывая неудобную логику проверок. FilmUsersLikes хранит в себе отдельный идентификатор likesCount для того, чтобы не проводить лишних расчётов, а данные для получения отсортированного списка фильмов брались их готов расчетов. 